### PR TITLE
BooleanField에 allow_null이 True인 경우 관련 버그 수정

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -689,6 +689,12 @@ class BooleanField(Field):
     }
     NULL_VALUES = {'null', 'Null', 'NULL', '', None}
 
+    def __init__(self, **kwargs):
+        if kwargs.get('allow_null', False):
+            self.default_empty_html = None
+            self.initial = None
+        super().__init__(**kwargs)
+
     def to_internal_value(self, data):
         try:
             if data in self.TRUE_VALUES:


### PR DESCRIPTION
관련 PR: https://github.com/encode/django-rest-framework/pull/8614

이 수정을 안하면 allow_null=True인 경우, 기본값이 False로 들어갑니다. 기본값이 null(None)이어야할텐데 말이죠.

지금 drf 최신버전이 3.14버전인데 3.14에 bugfix가 포함이 안되어있어서 직접 버그를 고칩니다.
나중에 drf다음 버전에서 bugfix가 되면 그 버전을 대신 사용하면 됩니다.